### PR TITLE
Defer notifications until after session response

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ If installed locally:
 }
 ```
 
+### JetBrains IDE Integration
+
+The adapter supports JetBrains IDEs (WebStorm, IntelliJ IDEA, PyCharm, etc.) version 25.3 and later.
+
+Create or edit `~/.jetbrains/acp.json`:
+
+```json
+{
+  "agent_servers": {
+    "Cursor Agent": {
+      "command": "cursor-agent-acp",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+Or configure through the IDE:
+1. Open **AI Chat** tool window
+2. Click ⚙️ settings → **"Configure ACP Agents"**
+3. Add the configuration above
+
 ### Using with Other Editors
 
 The adapter works with any ACP-compliant editor using the standard stdio transport. Configure your editor to launch `cursor-agent-acp` as an agent server process.

--- a/src/adapter/cursor-agent-adapter.ts
+++ b/src/adapter/cursor-agent-adapter.ts
@@ -922,7 +922,12 @@ export class CursorAgentAdapter implements ClientConnection {
     };
 
     // Per ACP spec: Agent MAY send available_commands_update notification after creating a session
-    this.sendAvailableCommandsUpdate(sessionData.id);
+    // IMPORTANT: Send notification AFTER returning response to avoid confusing clients
+    // that expect the response with matching id before any notifications.
+    // This is done via setImmediate to ensure the response is sent first.
+    setImmediate(() => {
+      this.sendAvailableCommandsUpdate(sessionData.id);
+    });
 
     return {
       jsonrpc: '2.0' as const,
@@ -1046,7 +1051,12 @@ export class CursorAgentAdapter implements ClientConnection {
     };
 
     // Per ACP spec: Agent MAY send available_commands_update notification after loading a session
-    this.sendAvailableCommandsUpdate(sessionId);
+    // IMPORTANT: Send notification AFTER returning response to avoid confusing clients
+    // that expect the response with matching id before any notifications.
+    // This is done via setImmediate to ensure the response is sent first.
+    setImmediate(() => {
+      this.sendAvailableCommandsUpdate(sessionId);
+    });
 
     return {
       jsonrpc: '2.0' as const,

--- a/tests/integration/slash-commands.test.ts
+++ b/tests/integration/slash-commands.test.ts
@@ -95,6 +95,7 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
@@ -105,6 +106,9 @@ describe('Slash Commands Integration', () => {
       expect(response.result).toBeDefined();
       const sessionResponse = response.result as NewSessionResponse;
       expect(sessionResponse.sessionId).toBeDefined();
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       // Find available_commands_update notification
       const commandsNotification = capturedNotifications.find(
@@ -132,10 +136,14 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       await adapter.processRequest(request);
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       const commandsNotification = capturedNotifications.find(
         (n) =>
@@ -164,12 +172,16 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       const createResponse = await adapter.processRequest(createRequest);
       expect(createResponse.result).toBeDefined();
       const sessionId = (createResponse.result as NewSessionResponse).sessionId;
+
+      // Wait for session/new notification
+      await new Promise((resolve) => setImmediate(resolve));
 
       // Clear captured notifications after session creation
       capturedNotifications.length = 0;
@@ -190,6 +202,9 @@ describe('Slash Commands Integration', () => {
 
       expect(loadResponse.error).toBeUndefined();
       expect(loadResponse.result).toBeDefined();
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       // Per ACP spec: Agent MAY send available_commands_update after loading a session
       // Note: This is optional per the spec, so if no commands are registered, no notification will be sent
@@ -429,10 +444,14 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       await adapter.processRequest(request);
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       const commandsNotification = capturedNotifications.find(
         (n) =>
@@ -461,10 +480,14 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       await adapter.processRequest(request);
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       const commandsNotification = capturedNotifications.find(
         (n) =>
@@ -587,10 +610,14 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       await adapter.processRequest(request);
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       const commandsNotification = capturedNotifications.find(
         (n) =>
@@ -616,10 +643,14 @@ describe('Slash Commands Integration', () => {
         method: 'session/new' as const,
         params: {
           cwd: process.cwd(),
+          mcpServers: [],
         },
       };
 
       await adapter.processRequest(request);
+
+      // Wait for async notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
 
       const commandsNotification = capturedNotifications.find(
         (n) =>

--- a/tests/unit/adapter/session-load.test.ts
+++ b/tests/unit/adapter/session-load.test.ts
@@ -327,6 +327,9 @@ describe('CursorAgentAdapter - session/load', () => {
 
       const sessionId = createResponse.result.sessionId;
 
+      // Wait for session/new notification to be sent
+      await new Promise((resolve) => setImmediate(resolve));
+
       // Clear notifications from creation
       sentNotifications = [];
 
@@ -345,8 +348,8 @@ describe('CursorAgentAdapter - session/load', () => {
 
       expect(response.result).toBeDefined();
 
-      // Wait a bit for notification to be sent
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Wait for notification to be sent (uses setImmediate)
+      await new Promise((resolve) => setImmediate(resolve));
 
       // Should have sent available_commands_update notification
       const commandNotifications = sentNotifications.filter(

--- a/tests/unit/adapter/session-new.test.ts
+++ b/tests/unit/adapter/session-new.test.ts
@@ -848,8 +848,8 @@ describe('session/new - Parameter Validation', () => {
       expect(response.result).toBeDefined();
       expect(response.result.sessionId).toBeDefined();
 
-      // Wait a bit for notification to be sent
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Wait for notification to be sent (uses setImmediate)
+      await new Promise((resolve) => setImmediate(resolve));
 
       // Should have sent available_commands_update notification
       const commandNotifications = sentNotifications.filter(


### PR DESCRIPTION
Use setImmediate() to send available_commands_update notifications after session/new and session/load responses are returned. This improves compatibility with JetBrains IDEs (WebStorm, IntelliJ) which expect the JSON-RPC response with the matching request id before receiving any notifications.

Fixes #33