### PR TITLE
Remove invalid cursor-agent peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,13 +40,7 @@
         "node": ">=18.14.0"
       },
       "peerDependencies": {
-        "cursor-agent": ">=1.0.0",
         "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "cursor-agent": {
-          "optional": false
-        }
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -3201,16 +3195,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cursor-agent": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cursor-agent/-/cursor-agent-1.0.3.tgz",
-      "integrity": "sha512-t+oFBD1CCfMgvW1uLQJMe7L4NJa8GSOf0XTG1vTa00QQspLJyrGhsrhNWxoez14Ba3LhFIECmsduOjL3sFdg0w==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
       }
     },
     "node_modules/debug": {
@@ -6376,6 +6360,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -92,12 +92,6 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "cursor-agent": ">=1.0.0",
     "zod": "^3.25.0 || ^4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "cursor-agent": {
-      "optional": false
-    }
   }
 }


### PR DESCRIPTION
cursor-agent is a CLI tool installed externally (e.g., via Homebrew), not an npm package. The codebase interacts with it via child_process spawn(), so listing it as a peer dependency was incorrect and would cause npm to warn about a missing package that doesn't exist.