### PR TITLE
Make --force flag opt-in for cursor-agent

### DIFF
--- a/src/bin/cursor-agent-acp.ts
+++ b/src/bin/cursor-agent-acp.ts
@@ -30,6 +30,7 @@ interface CliOptions {
   noFilesystem?: boolean;
   noTerminal?: boolean;
   maxProcesses: string;
+  force?: boolean;
   verbose?: boolean;
   quiet?: boolean;
   validate?: boolean;
@@ -111,6 +112,7 @@ program
     'maximum number of terminal processes',
     '5'
   )
+  .option('--force', 'pass --force to cursor-agent (allow all commands without prompting)')
   .option('-v, --verbose', 'enable verbose logging')
   .option('-q, --quiet', 'suppress all output except errors')
   .option('--validate', 'validate configuration and exit')
@@ -333,6 +335,9 @@ async function main(): Promise<void> {
     }
     if (options.noTerminal) {
       config.tools.terminal.enabled = false;
+    }
+    if (options.force) {
+      config.cursor.force = true;
     }
 
     // Validate configuration

--- a/src/cursor/cli-bridge.ts
+++ b/src/cursor/cli-bridge.ts
@@ -575,7 +575,7 @@ export class CursorCliBridge {
           '--print',
           '--output-format',
           'json',
-          '--force', // Allow commands unless explicitly denied
+          ...(this.config.cursor.force ? ['--force'] : []),
           content.value,
         ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,6 +303,7 @@ export interface AdapterConfig {
   cursor: {
     timeout: number;
     retries: number;
+    force?: boolean;
   };
 }
 


### PR DESCRIPTION
Previously, --force was always passed to cursor-agent, allowing all commands to run without prompting. This changes the behavior so that cursor-agent will prompt for approval by default, and --force must be explicitly provided via the CLI to bypass prompts.