### PR TITLE
fix: use os.tmpdir() for temp file path to fix ENOENT on Windows

### DIFF
--- a/src/cursor/cli-bridge.ts
+++ b/src/cursor/cli-bridge.ts
@@ -6,6 +6,8 @@
  */
 
 import { spawn, ChildProcess } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
   CursorError,
   type AdapterConfig,
@@ -564,8 +566,8 @@ export class CursorCliBridge {
         cwd: workingDir,
       });
 
-      // Create a temporary file for the prompt content
-      const tempFile = `/tmp/cursor-prompt-${Date.now()}.txt`;
+      // Create a temporary file for the prompt content (use OS temp dir for cross-platform support)
+      const tempFile = join(tmpdir(), `cursor-prompt-${Date.now()}.txt`);
       const fs = await import('fs/promises');
       await fs.writeFile(tempFile, content.value, 'utf8');
 


### PR DESCRIPTION
The hardcoded /tmp/ path resolves to a non-existent directory on Windows (e.g. F:\tmp\) when the working directory is on a non-C: drive, causing prompt processing to fail with a misleading 'cursor-agent CLI not installed' error.

Made-with: Cursor